### PR TITLE
Quick fix for me to log in

### DIFF
--- a/www/login.php
+++ b/www/login.php
@@ -41,7 +41,7 @@ if ($_POST) {
         ldap_close($con);
         $success = false;
         for ($i = 0; $i < $entries[0][LDAP_GROUP_ATTR]['count']; $i++) {
-          if ($entries[0][LDAP_GROUP_ATTR][$i] == $udn) {
+          if ($entries[0][LDAP_GROUP_ATTR][$i] == $username) {
             $_SESSION['id'] = $username;
             $success = true;
             writeLog('login-access.log',$udn.' '.logged_in);


### PR DESCRIPTION
Hi Felipe,

I had to change back to $username because, at least in my test environment, the memberships for LDAP_AUTH_GROUP seem to work comparing the bare uids and not their distinguished names.
    
Keep up that good work, just started going through it!